### PR TITLE
Add ESS Store as nav_button and ESS Bookings as external link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -101,6 +101,16 @@ URL = "contact"
 name = "Contact us"
 weight = 6
 
+[[menu.external_link]]
+URL = "https://ess-bookings.square.site/"
+name = "Bookings"
+
+# ESS Store
+[params.nav_button]
+enable = true
+label = "ESS Store"
+link = "https://ucalgary-engineering-students-society.square.site/"
+
 [params]
 
 # Details
@@ -135,12 +145,6 @@ text = "COVID-19 Information"
 [params.officehours]
 enable = true
 link = "/about/officehours"
-
-# Bookings
-[params.nav_button]
-enable = true
-label = "Bookings"
-link = "https://ess-bookings.square.site/"
 
 # Plugins
 [[params.plugins.css]]

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -494,3 +494,44 @@ img.carousel-card-image {
 .career-fair-company {
   text-align: center;
 }
+
+/* 
+https://stackoverflow.com/questions/19827605/how-to-change-bootstrap-navbar-collapse-breakpoint
+Bootstrap 3 doesn't have support for changing the breakpoint for the collapsed navbar. Manually added a breakpoint with a media query.
+*/
+@media (max-width: 1200px) {
+  .navbar-header {
+      float: none;
+  }
+  .navbar-left,.navbar-right {
+      float: none !important;
+  }
+  .navbar-toggle {
+      display: block;
+  }
+  .navbar-collapse {
+      border-top: 1px solid transparent;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+  }
+  .navbar-fixed-top {
+      top: 0;
+      border-width: 0 0 1px;
+  }
+  .navbar-collapse.collapse {
+      display: none!important;
+  }
+  .navbar-nav {
+      float: none!important;
+      margin-top: 7.5px;
+  }
+  .navbar-nav>li {
+      float: none;
+  }
+  .navbar-nav>li>a {
+      padding-top: 10px;
+      padding-bottom: 10px;
+  }
+  .collapse.in{
+      display:block !important;
+  }
+}

--- a/themes/airspace-hugo/layouts/partials/header.html
+++ b/themes/airspace-hugo/layouts/partials/header.html
@@ -55,11 +55,16 @@
               </li>
               {{ else }}
               <li><a href="{{ .URL | absLangURL }}">{{ .Name }}</a></li>
-              {{ end }} {{ end }} {{ if .Site.Params.nav_button}}
+              {{ end }} {{ end }} 
+              {{ range .Site.Menus.external_link}}
+                <li><a href="{{ .URL | absLangURL }}" target="_blank">{{ .Name }}</a></li>
+              {{ end }}
+              {{ if .Site.Params.nav_button}}
               <li>
                 <a
                   class="btn btn-main"
                   id="btn-nav"
+                  target="_blank"
                   href="{{ .Site.Params.nav_button.link | absLangURL }}"
                   >{{.Site.Params.nav_button.label}}</a
                 >


### PR DESCRIPTION
Adding a link to the square website where people can buy memberships and other items online.

- Added ESS Store as the red Nav button. Link opens in new tab.
- Converted ESS booking to 'external link' type and set it so that 'external links' also open in a new tab.