### PR TITLE
Update: Winter Career Fair Registration Link

### DIFF
--- a/content/english/events/featured-events/career-fair/_index.md
+++ b/content/english/events/featured-events/career-fair/_index.md
@@ -3,10 +3,11 @@ title: "Career Fair"
 description: "Build your soft skills and network!"
 bg_image: "/images/events/2023/career-fair/career-fair-ad.jpg"
 layout: "career-fair"
-registration_link: "https://forms.gle/mS6kxzKNJgsNwGYg7"
+# registration_link: "https://forms.gle/mS6kxzKNJgsNwGYg7"
 ---
 
 The ESS's Fall and Winter career fairs allow engineering students the chance to gain valuable industry connections firsthand. From local startups to big names, there will be a wide selection of companies for students to check out for their future career prospects. It's never too early or too late to build up your network, so please come out and see what opportunities you might find!
 
 The 2025 Winter career fair is being held on **Wednesday, February 5, 2025, from 10:00 am - 3:00 pm in the ENGG Lounge**.
-Registration is required for this event, so please register and we'll see you there!
+<!-- Registration is required for this event, so please register and we'll see you there! -->
+**Registration opens in late January**.

--- a/content/english/events/featured-events/career-fair/_index.md
+++ b/content/english/events/featured-events/career-fair/_index.md
@@ -3,7 +3,7 @@ title: "Career Fair"
 description: "Build your soft skills and network!"
 bg_image: "/images/events/2023/career-fair/career-fair-ad.jpg"
 layout: "career-fair"
-# registration_link: "https://forms.gle/mS6kxzKNJgsNwGYg7"
+registration_link: "https://forms.gle/mS6kxzKNJgsNwGYg7"
 ---
 
 The ESS's Fall and Winter career fairs allow engineering students the chance to gain valuable industry connections firsthand. From local startups to big names, there will be a wide selection of companies for students to check out for their future career prospects. It's never too early or too late to build up your network, so please come out and see what opportunities you might find!

--- a/themes/airspace-hugo/layouts/events/career-fair.html
+++ b/themes/airspace-hugo/layouts/events/career-fair.html
@@ -6,12 +6,12 @@
     <div class="row">
       <h2>{{.Title}}</h2>
       {{.Content }}
-      <a
+      <!-- <a
         class="btn btn-main"
         href="{{.Params.registration_link}}"
         target="_blank"
         >REGISTER NOW
-      </a>
+      </a> -->
     </div>
   </div>
   <div class="container">


### PR DESCRIPTION
Removing registration link until late January so External can finalize sponsors